### PR TITLE
Fix Issue #6: 実際のマイク音声がキャプチャされない問題を修正

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -20,7 +20,7 @@ export default defineManifest({
       '128': 'icons/icon-128.png',
     },
   },
-  permissions: ['storage', 'scripting', 'contextMenus'],
+  permissions: ['storage', 'scripting', 'contextMenus', 'offscreen'],
   host_permissions: ['https://www.notion.so/*', 'https://api.openai.com/*'],
   background: {
     service_worker: 'src/background/index.ts',
@@ -35,7 +35,7 @@ export default defineManifest({
   ],
   web_accessible_resources: [
     {
-      resources: ['src/content/audio-permission.html'],
+      resources: ['src/content/audio-permission.html', 'src/offscreen/offscreen.html'],
       matches: ['https://www.notion.so/*'],
     },
   ],

--- a/src/offscreen/offscreen.html
+++ b/src/offscreen/offscreen.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Voice Transcribe - Offscreen Document</title>
+</head>
+<body>
+    <script type="module" src="./offscreen.ts"></script>
+</body>
+</html>

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -1,0 +1,291 @@
+/// <reference types="chrome" />
+
+import { blobToBase64, formatDataSize } from '../utils/audio-processor';
+
+// グローバル変数
+let mediaRecorder: MediaRecorder | null = null;
+let mediaStream: MediaStream | null = null;
+let audioChunks: Blob[] = [];
+let isRecording = false;
+let isPaused = false;
+
+// 録音設定
+const RECORDING_CONFIG = {
+  mimeType: 'audio/webm;codecs=opus',
+  audioBitsPerSecond: 128000, // 128kbps
+  timeslice: 1000, // 1秒ごとにデータを送信
+};
+
+interface MessageRequest {
+  action: string;
+  [key: string]: any;
+}
+
+// メッセージハンドラー
+chrome.runtime.onMessage.addListener((request: MessageRequest, _sender, sendResponse) => {
+  console.log('Offscreen: メッセージを受信:', request);
+
+  switch (request.action) {
+    case 'startRecording':
+      void startRecording()
+        .then(() => {
+          sendResponse({ success: true });
+        })
+        .catch((error: Error) => {
+          sendResponse({ success: false, error: error.message });
+        });
+      break;
+
+    case 'stopRecording':
+      try {
+        stopRecording();
+        sendResponse({ success: true });
+      } catch (error) {
+        sendResponse({
+          success: false,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
+      break;
+
+    case 'pauseRecording':
+      pauseRecording();
+      sendResponse({ success: true });
+      break;
+
+    case 'resumeRecording':
+      resumeRecording();
+      sendResponse({ success: true });
+      break;
+
+    case 'getRecordingStatus':
+      sendResponse({
+        isRecording,
+        isPaused,
+        mimeType: RECORDING_CONFIG.mimeType,
+        hasMediaStream: !!mediaStream,
+        hasMediaRecorder: !!mediaRecorder,
+      });
+      break;
+
+    default:
+      sendResponse({ success: false, error: 'Unknown action' });
+  }
+
+  return true; // 非同期レスポンス
+});
+
+// 録音開始
+async function startRecording(): Promise<void> {
+  try {
+    console.log('Offscreen: 録音を開始します');
+
+    // 既存のストリームがある場合は停止
+    if (mediaStream) {
+      mediaStream.getTracks().forEach((track) => track.stop());
+    }
+
+    // マイクアクセス権限を取得
+    mediaStream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        sampleRate: 44100,
+        channelCount: 1,
+      },
+    });
+
+    console.log('Offscreen: マイクストリームを取得しました');
+
+    // MediaRecorderを初期化
+    if (!MediaRecorder.isTypeSupported(RECORDING_CONFIG.mimeType)) {
+      throw new Error(`MimeType ${RECORDING_CONFIG.mimeType} is not supported`);
+    }
+
+    mediaRecorder = new MediaRecorder(mediaStream, {
+      mimeType: RECORDING_CONFIG.mimeType,
+      audioBitsPerSecond: RECORDING_CONFIG.audioBitsPerSecond,
+    });
+
+    // イベントリスナーを設定
+    setupMediaRecorderEvents();
+
+    // 録音開始
+    audioChunks = [];
+    mediaRecorder.start(RECORDING_CONFIG.timeslice);
+    isRecording = true;
+    isPaused = false;
+
+    console.log('Offscreen: MediaRecorderが開始されました');
+
+    // バックグラウンドスクリプトに通知
+    void chrome.runtime.sendMessage({
+      action: 'recordingStarted',
+      mimeType: RECORDING_CONFIG.mimeType,
+    });
+  } catch (error) {
+    console.error('Offscreen: 録音開始エラー:', error);
+    isRecording = false;
+    isPaused = false;
+
+    // エラーを通知
+    void chrome.runtime.sendMessage({
+      action: 'recordingError',
+      error: error instanceof Error ? error.message : 'Unknown error',
+      errorType: error instanceof Error ? error.name : 'UnknownError',
+    });
+
+    throw error;
+  }
+}
+
+// 録音停止
+function stopRecording(): void {
+  try {
+    console.log('Offscreen: 録音を停止します');
+
+    if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+      mediaRecorder.stop();
+    }
+
+    if (mediaStream) {
+      mediaStream.getTracks().forEach((track) => track.stop());
+      mediaStream = null;
+    }
+
+    isRecording = false;
+    isPaused = false;
+
+    console.log('Offscreen: 録音が停止されました');
+  } catch (error) {
+    console.error('Offscreen: 録音停止エラー:', error);
+    throw error;
+  }
+}
+
+// 録音一時停止
+function pauseRecording(): void {
+  if (mediaRecorder && mediaRecorder.state === 'recording') {
+    mediaRecorder.pause();
+    isPaused = true;
+    console.log('Offscreen: 録音が一時停止されました');
+
+    void chrome.runtime.sendMessage({
+      action: 'recordingPaused',
+    });
+  }
+}
+
+// 録音再開
+function resumeRecording(): void {
+  if (mediaRecorder && mediaRecorder.state === 'paused') {
+    mediaRecorder.resume();
+    isPaused = false;
+    console.log('Offscreen: 録音が再開されました');
+
+    chrome.runtime.sendMessage({
+      action: 'recordingResumed',
+    });
+  }
+}
+
+// MediaRecorderイベントの設定
+function setupMediaRecorderEvents(): void {
+  if (!mediaRecorder) return;
+
+  mediaRecorder.addEventListener('dataavailable', async (event) => {
+    if (event.data.size > 0) {
+      audioChunks.push(event.data);
+      console.log(`Offscreen: 音声データチャンクを受信: ${formatDataSize(event.data.size)}`);
+
+      try {
+        // 音声データをBase64に変換してバックグラウンドスクリプトに送信
+        const base64Data = await blobToBase64(event.data);
+        chrome.runtime.sendMessage({
+          action: 'audioDataChunk',
+          data: base64Data,
+          mimeType: RECORDING_CONFIG.mimeType,
+          timestamp: Date.now(),
+          size: event.data.size,
+        });
+      } catch (error) {
+        console.error('Offscreen: 音声データの変換エラー:', error);
+      }
+    }
+  });
+
+  mediaRecorder.addEventListener('stop', async () => {
+    console.log('Offscreen: MediaRecorderが停止されました');
+
+    try {
+      // 全ての音声データを結合
+      const finalBlob = new Blob(audioChunks, { type: RECORDING_CONFIG.mimeType });
+      const finalBase64 = await blobToBase64(finalBlob);
+
+      console.log(`Offscreen: 最終的な音声データ: ${formatDataSize(finalBlob.size)}`);
+
+      // バックグラウンドスクリプトに最終データを送信
+      chrome.runtime.sendMessage({
+        action: 'recordingComplete',
+        data: finalBase64,
+        mimeType: RECORDING_CONFIG.mimeType,
+        size: finalBlob.size,
+        duration: audioChunks.length, // 概算的な長さ
+      });
+
+      // クリーンアップ
+      audioChunks = [];
+      mediaRecorder = null;
+    } catch (error) {
+      console.error('Offscreen: 録音完了処理エラー:', error);
+      chrome.runtime.sendMessage({
+        action: 'recordingError',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+
+    chrome.runtime.sendMessage({
+      action: 'recordingStopped',
+    });
+  });
+
+  mediaRecorder.addEventListener('error', (event) => {
+    console.error('Offscreen: MediaRecorderエラー:', event.error);
+    isRecording = false;
+    isPaused = false;
+
+    chrome.runtime.sendMessage({
+      action: 'recordingError',
+      error: event.error?.message || 'MediaRecorder error',
+      errorType: event.error?.name || 'MediaRecorderError',
+    });
+  });
+}
+
+// ページロード時の初期化
+console.log('Offscreen: ドキュメントが読み込まれました');
+
+// ポートベースでService WorkerにREADYシグナルを送信
+chrome.runtime.onConnect.addListener((port) => {
+  if (port.name === 'offscreen') {
+    console.log('Offscreen: Service Workerからのポート接続を受信しました');
+    port.postMessage({ type: 'READY' });
+    console.log('Offscreen: READYシグナルを送信しました');
+
+    // 録音コマンドを受信
+    port.onMessage.addListener(async (msg: any) => {
+      if (msg && typeof msg === 'object' && 'type' in msg) {
+        switch ((msg as { type: string }).type) {
+          case 'START_RECORD':
+            console.log('Offscreen: 録音開始コマンドを受信しました');
+            await startRecording();
+            break;
+          case 'STOP_RECORD':
+            console.log('Offscreen: 録音停止コマンドを受信しました');
+            stopRecording();
+            break;
+        }
+      }
+    });
+  }
+});

--- a/src/utils/__tests__/recording-state-sync.test.ts
+++ b/src/utils/__tests__/recording-state-sync.test.ts
@@ -34,7 +34,7 @@ describe('Recording State Synchronization', () => {
 
       expect(mockChrome.storage.local.set).toHaveBeenCalledWith(
         { isRecording: true },
-        expect.any(Function)
+        expect.any(Function),
       );
     });
 
@@ -49,7 +49,7 @@ describe('Recording State Synchronization', () => {
 
       expect(mockChrome.storage.local.set).toHaveBeenCalledWith(
         { isRecording: false },
-        expect.any(Function)
+        expect.any(Function),
       );
     });
 
@@ -87,36 +87,30 @@ describe('Recording State Synchronization', () => {
 
       // メッセージを送信
       return new Promise<void>((resolve) => {
-        mockChrome.runtime.sendMessage(
-          { action: 'getRecordingStatus' },
-          (response) => {
-            expect(response.isRecording).toBe(true);
-            expect(response.isPaused).toBe(false);
-            expect(response.mimeType).toBe('audio/webm');
-            resolve();
-          }
-        );
+        mockChrome.runtime.sendMessage({ action: 'getRecordingStatus' }, (response) => {
+          expect(response.isRecording).toBe(true);
+          expect(response.isPaused).toBe(false);
+          expect(response.mimeType).toBe('audio/webm');
+          resolve();
+        });
       });
     });
 
     it('should handle runtime errors gracefully', async () => {
       // エラーをシミュレート
       mockChrome.runtime.lastError = { message: 'Connection error' };
-      
+
       mockChrome.runtime.sendMessage.mockImplementation((message, callback) => {
         callback(null);
       });
 
       // メッセージを送信
       return new Promise<void>((resolve) => {
-        mockChrome.runtime.sendMessage(
-          { action: 'getRecordingStatus' },
-          (response) => {
-            expect(mockChrome.runtime.lastError).toBeTruthy();
-            expect(response).toBeNull();
-            resolve();
-          }
-        );
+        mockChrome.runtime.sendMessage({ action: 'getRecordingStatus' }, (response) => {
+          expect(mockChrome.runtime.lastError).toBeTruthy();
+          expect(response).toBeNull();
+          resolve();
+        });
       });
     });
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,11 @@ export default defineConfig({
   },
   build: {
     rollupOptions: {
+      input: {
+        // メインエントリポイント
+        popup: 'popup.html',
+        offscreen: 'src/offscreen/offscreen.html',
+      },
       output: {
         chunkFileNames: 'assets/[name]-[hash].js',
         entryFileNames: 'assets/[name]-[hash].js',


### PR DESCRIPTION
## 概要
Issue #6「実際のマイク音声がキャプチャされない」問題を修正しました。

## 修正内容

### 1. Offscreen Document APIの実装
- 理由で30秒自動タイムアウトを回避
- MediaRecorderによる実際の音声キャプチャ
- 一度だけ作成・再利用パターンで二重生成を防止

### 2. READYハンドシェイクパターンの実装
- ポートベース通信で確実な接続
- 競合状態の完全解決
- 'Could not establish connection' エラーの修正

### 3. vite.config.tsの修正
- offscreen.htmlをビルドプロセスに追加
- 正しいJSファイルパスの自動設定

## 動作確認
- ✅ マイク音声キャプチャが継続動作
- ✅ READYタイムアウトエラーが解決
- ✅ 30秒自動切断問題が回避
- ✅ Chrome Extension Manifest V3完全対応

## 関連Issue
Closes #6

## テスト
- 手動テストでマイク音声キャプチャの動作確認済み
- macOSのマイクインジケーターが継続表示されることを確認